### PR TITLE
Added hostname/port parameters to Controller.Run() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,15 @@ hardware:
 Set Controller = CreateObject(“MPF.Controller”)
 ```
 
-4. If your mpf instance is running on a different machine than the one running Visual Pinball then tell the bridge where to connect using the run command parameters
+4. If your mpf instance is running on a different machine than the machine running Visual Pinball then tell the bridge where to connect using the Controller.Run() command parameters
+- Default BCP server will listen on the loopbak/localhost interface so In order for this to work you need to tell your bcp server to listen on external network interface by altering your config.yaml file as following
+```
+bcp:
+    servers:
+        url_style:
+            ip: 0.0.0.0
+```
+- Update your table script to specify the address and/or port of your server in the 
 ```
 #Ex 1 : Different machine on port 5051
 Controller.Run "mypinball"
@@ -20,6 +28,7 @@ Controller.Run "mypinball"
 #Ex 2 : Different machine and different port
 Controller.Run "mypinball", 1337
 ```
+
 
 To run a game:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,18 @@ hardware:
     platform: virtual_pinball
  
 3. In VPX edit script and replace the controller with:
+```
 Set Controller = CreateObject(“MPF.Controller”)
+```
+
+4. If your mpf instance is running on a different machine than the one running Visual Pinball then tell the bridge where to connect using the run command parameters
+```
+#Ex 1 : Different machine on port 5051
+Controller.Run "mypinball"
+
+#Ex 2 : Different machine and different port
+Controller.Run "mypinball", 1337
+```
 
 To run a game:
 

--- a/register_vpcom.py
+++ b/register_vpcom.py
@@ -140,23 +140,19 @@ class Controller:
         logging.getLogger('vpcom').info("PrintGlobal called.")
         return True
 
-    def _connect(self):
+    def _connect(self, addr, port):
         """Connect to MPF."""
         try:
-            reader, writer = self.loop.run_until_complete(asyncio.open_connection("localhost", 5051))
+            reader, writer = self.loop.run_until_complete(asyncio.open_connection(addr, port))
             self.bcp_client = AsyncioBcpClientSocket(writer, reader)
         except Exception as e:
             raise COMException(desc="Failed to connect to MPF: {}".format(e), scode=winerror.E_FAIL)
 
-    def Run(self, extra_arg=None):
+    def Run(self, addr="localhost", port=5051):
         """Connect to MPF."""
-        if extra_arg is not None:
-            logging.getLogger('vpcom').info("Run received extra arg!?")
-            logging.getLogger('vpcom').info("Arg was {0}".format(extra_arg))
+        logging.getLogger('vpcom').info("Starting bridge. Connecting to {}:{}".format(addr,port))
 
-        logging.getLogger('vpcom').info("Starting bridge. Connecting to localhost:5051")
-
-        self._connect()
+        self._connect(addr, port)
 
         self.bcp_client.send("vpcom_bridge", {"subcommand": "start"})
         self.loop.run_until_complete(self.bcp_client.wait_for_response("vpcom_bridge_response"))


### PR DESCRIPTION
By default the bridget will try to connect to localhost on port 5051.
This PR goal is to introduce a way to connect to a remote BCP server.
So If mpf runs on a different machine than the one where Visual Pinball run it is now possible to do it via the Controller.Run call