### PR TITLE
LED Brightness from MPF

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ mpf_vpcom_bridge.exe
 ```
 NOTE: The exe may not be included in the PATH for Windows by default. It may be located in the Scripts folder of the MPF venv, for example: C:\Users\Me\\.local\pipx\venvs\mpf\Scripts\mpf_vpcom_bridge.exe where Me is the Windows username for the session.
 
-4. The bridge can be unregistered by passing the following argument to the exe as Administrator:
+4. If no longer needed, the bridge can be unregistered by passing the following argument to the exe as Administrator:
 ```
 mpf_vpcom_bridge.exe --unregister
 ```

--- a/README.md
+++ b/README.md
@@ -32,14 +32,23 @@ Controller.Run "mypinball", 1337
 
 
 Instructions for MPF installed via `pipx`:
+The latest official installation instructions for MPF utilize `pipx` to create a virtual environment (venv) for MPF to run in. To install the mpf-visual-pinball bridge, it must be injected into the MPF venv.
+1.  Open a command prompt and change directories (cd) to the folder containing the mpf_vpcom_bridge source code.
 
+2. Run the following command to inject mpf_vpcom_bridge into the MPF venv.
 ```
 pipx inject mpf ./
-
+```
+3. To register the bridge with Windows as a COM object, the following exe must be run as Administrator. 
+```
 mpf_vpcom_bridge.exe
 ```
+NOTE: The exe may not be included in the PATH for Windows by default. It may be located in the Scripts folder of the MPF venv, for example: C:\Users\Me\.local\pipx\venvs\mpf\Scripts\mpf_vpcom_bridge.exe where Me is the Windows username for the session.
 
-
+4. The bridge can be unregistered be passing the following argument to the exe as Administrator:
+```
+mpf_vpcom_bridge.exe --unregister
+```
 
 To run a game:
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ pipx inject mpf ./
 ```
 mpf_vpcom_bridge.exe
 ```
-NOTE: The exe may not be included in the PATH for Windows by default. It may be located in the Scripts folder of the MPF venv, for example: C:\Users\Me\.local\pipx\venvs\mpf\Scripts\mpf_vpcom_bridge.exe where Me is the Windows username for the session.
+NOTE: The exe may not be included in the PATH for Windows by default. It may be located in the Scripts folder of the MPF venv, for example: C:\Users\Me\\.local\pipx\venvs\mpf\Scripts\mpf_vpcom_bridge.exe where Me is the Windows username for the session.
 
-4. The bridge can be unregistered be passing the following argument to the exe as Administrator:
+4. The bridge can be unregistered by passing the following argument to the exe as Administrator:
 ```
 mpf_vpcom_bridge.exe --unregister
 ```

--- a/mpf_vpcom_bridge/main.py
+++ b/mpf_vpcom_bridge/main.py
@@ -90,6 +90,7 @@ class Controller:
         'ChangedGIStrings',
         'ChangedLamps',
         'ChangedLEDs',
+        'ChangedBrightnessLEDs',
         'ChangedFlashers',
         'HardwareRules',
         'GetMech'
@@ -101,6 +102,7 @@ class Controller:
         'ChangedLamps',
         'ChangedGIStrings',
         'ChangedLEDs',
+        'ChangedBrightnessLEDs',
         'ChangedFlashers',
         'HardwareRules',
         'GetMech'
@@ -246,7 +248,11 @@ class Controller:
     def ChangedLEDs(self):
         """Return a list of changed lamps."""
         return self._dispatch_to_mpf("changed_leds")
-
+        
+    def ChangedBrightnessLEDs(self):
+        """Return a list of changed lamps."""
+        return self._dispatch_to_mpf("changed_brightness_leds")
+        
     def ChangedFlashers(self):
         """Return a list of changed GI strings."""
         return self._dispatch_to_mpf("changed_flashers")

--- a/mpf_vpcom_bridge/main.py
+++ b/mpf_vpcom_bridge/main.py
@@ -250,7 +250,7 @@ class Controller:
         return self._dispatch_to_mpf("changed_leds")
         
     def ChangedBrightnessLEDs(self):
-        """Return a list of changed lamps."""
+        """Return a list of changed LEDs with brightness vlaues as floats."""
         return self._dispatch_to_mpf("changed_brightness_leds")
         
     def ChangedFlashers(self):


### PR DESCRIPTION
These changes allow VPX to receive floating point brightness from MPF, rather than the original boolean state for an LED.
NOTE: These changes are dependent on corresponding changes in MPF made on this PR: https://github.com/missionpinball/mpf/pull/1666
